### PR TITLE
Potential fix for code scanning alert no. 65: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -18,7 +18,9 @@ class ErrorWithParent extends Error {
 // vuln-code-snippet start unionSqlInjectionChallenge dbSchemaChallenge
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
-    let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    let criteria: string = typeof req.query.q === 'string'
+      ? (req.query.q === 'undefined' ? '' : req.query.q)
+      : ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/aborgespoke2006/juice-shop/security/code-scanning/65](https://github.com/aborgespoke2006/juice-shop/security/code-scanning/65)

To fix the problem, explicitly check that the query parameter `req.query.q` is a string before using it. If it is not a string (i.e., it is an array or another type), you should fallback to a safe default value (such as `''`) or reject the request. The best fix is to modify the assignment on line 21 (and possibly 22) to ensure that `criteria` is a string, and apply no string methods or SQL concatenation to untrusted values of another type. This is achieved using a `typeof` check. Since all further processing expects `criteria` to be a string, you can set `criteria` to `''` (safe empty search) unless `req.query.q` is of type `'string'`.

**Required changes:**
- In the `searchProducts` handler, change the assignment to `criteria` to first check `typeof req.query.q === 'string'`. Only if it is a string, use its value; otherwise use `''` or a safe fallback.
- The rest of the function can safely use string methods on `criteria`.

**Files to change:**  
Only in `routes/search.ts`: modify lines 21–22.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
